### PR TITLE
Collect logs context switch

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,6 +239,6 @@ The following environment parameters are supported for log collection:
 
 | Parameters | Description                                            | Default                                                                                                                           |
 |------------|:-------------------------------------------------------|:----------------------------------------------------------------------------------------------------------------------------------|
-| -reelease  | Helm release name                                      | `trendmicro`                                                                                                                      |
+| -release  | Helm release name                                      | `trendmicro`                                                                                                                      |
 | -namespace | The namespace that the helm chart is deployed in       | Current namespace declared in `kubeconfig`. If no namespace setting exists in `kubeconfig`, then `trendmicro-system` will be used. |
 | -context   | The Kluster context that the helm chart is deployed in | Current cluster declared in `kubeconfig`. |

--- a/README.md
+++ b/README.md
@@ -235,9 +235,10 @@ Gather logs using the following command:
 ./collect-logs.sh
 ```
 
-The following environment variables are supported for log collection:
+The following environment parameters are supported for log collection:
 
-| Environment variable      | Description                             | Default                                                                                        |
-| ------------------------- |:----------------------------------------|:-----------------------------------------------------------------------------------------------|
-| RELEASE                   | Helm release name                       | `trendmicro`                                                                         |
-| NAMESPACE                 | The namespace that the helm chart is deployed in | Current namespace declared in `kubeconfig`. If no namespace setting exists in `kubeconfig`, then `trendmicro-system` will be used. |
+| Parameters | Description                                            | Default                                                                                                                           |
+|------------|:-------------------------------------------------------|:----------------------------------------------------------------------------------------------------------------------------------|
+| -reelease  | Helm release name                                      | `trendmicro`                                                                                                                      |
+| -namespace | The namespace that the helm chart is deployed in       | Current namespace declared in `kubeconfig`. If no namespace setting exists in `kubeconfig`, then `trendmicro-system` will be used. |
+| -context   | The Kluster context that the helm chart is deployed in | Current cluster declared in `kubeconfig`. |

--- a/collect-logs.sh
+++ b/collect-logs.sh
@@ -3,9 +3,30 @@
 # a helper script to fetch Kubernetes settings and Trend Micro Cloud One container security logs.
 #
 
-RELEASE=${RELEASE:-trendmicro}
+RELEASE="trendmicro"
 KUBECTL=kubectl
 HELM=helm
+CONTEXT=""
+
+help()
+{
+cat << EOF
+Helper script to fetch Kubernetes setting and DTrend Micro Cloud One container security logs.
+Options:
+-release          [Optional] Specifies the Trend Micro Cloud One container security release name. The default is trendmicro
+-namespace        [Optional] Specifies the the namespace of Trend Micro Cloud One container security deployment.
+                             The default is the current namespace or default.
+-corefilepattern  [Optional] S[ecifies the core dump file name prefix pattern. The default value is 'core'.
+-resultdir        [Optional] Specifies the directory to save the logs.
+Usage examples:
+# Display this help
+./collect-logs.sh -h | H
+# Collect logs for the default release, namespace and context
+./collect-logs.sh
+# Collect logs for the named release, namespace and context
+./collect-logs.sh -release deepsecurity-smartcheck -namespace trendmicro -context kubernetes-cluster
+EOF
+}
 
 #####
 # check prerequisites
@@ -24,10 +45,47 @@ if ! command_exists $HELM; then
   exit 1
 fi
 
+while [[ $# -gt 0 ]]
+do
+  key="$1"
+  case $key in
+    -h|-H)
+      help
+      exit 0
+      ;;
+    -release)
+     RELEASE=$2
+     shift
+     shift
+     ;;
+    -namespace)
+     NAMESPACE=$2
+     shift
+     shift
+     ;;
+    -context)
+     CONTEXT=$2
+     shift
+     shift
+     ;;
+    *)
+     echo "Unrecognized options are specified: $1"
+     echo "Use option -h for help."
+     exit 1
+    ;;
+  esac
+done
+
 CURRENT_NS=$(kubectl config view --minify --output 'jsonpath={..namespace}')
 CURRENT_NS=${CURRENT_NS:-trendmicro-system}
 NAMESPACE=${NAMESPACE:-$CURRENT_NS}
 NAMESPACE_PARAM="--namespace=$NAMESPACE"
+
+CURRENT_CONTEXT=$(kubectl config view --minify --output 'jsonpath={.current-context}')
+CONTEXT=${CONTEXT:-$CURRENT_CONTEXT}
+CONTEXT_PARAM="--context=$CONTEXT"
+
+KUBECTL="$KUBECTL $CONTEXT_PARAM"
 
 PODS=$($KUBECTL get pods "$NAMESPACE_PARAM" -o=jsonpath='{range .items[*]}{.metadata.name}{";"}{end}' -l app.kubernetes.io/instance=$RELEASE)
 if [ -z "${PODS}" ]; then

--- a/collect-logs.sh
+++ b/collect-logs.sh
@@ -11,7 +11,7 @@ CONTEXT=""
 help()
 {
 cat << EOF
-Helper script to fetch Kubernetes setting and DTrend Micro Cloud One container security logs.
+Helper script to fetch Kubernetes settings and Trend Micro Cloud One container security logs.
 Options:
 -release          [Optional] Specifies the Trend Micro Cloud One container security release name. The default is trendmicro
 -namespace        [Optional] Specifies the the namespace of Trend Micro Cloud One container security deployment.

--- a/collect-logs.sh
+++ b/collect-logs.sh
@@ -16,7 +16,6 @@ Options:
 -release          [Optional] Specifies the Trend Micro Cloud One container security release name. The default is trendmicro
 -namespace        [Optional] Specifies the the namespace of Trend Micro Cloud One container security deployment.
                              The default is the current namespace or default.
--corefilepattern  [Optional] Specifies the core dump file name prefix pattern. The default value is 'core'.
 Usage examples:
 # Display this help
 ./collect-logs.sh -h | H

--- a/collect-logs.sh
+++ b/collect-logs.sh
@@ -16,7 +16,7 @@ Options:
 -release          [Optional] Specifies the Trend Micro Cloud One container security release name. The default is trendmicro
 -namespace        [Optional] Specifies the the namespace of Trend Micro Cloud One container security deployment.
                              The default is the current namespace or default.
--corefilepattern  [Optional] S[ecifies the core dump file name prefix pattern. The default value is 'core'.
+-corefilepattern  [Optional] Specifies the core dump file name prefix pattern. The default value is 'core'.
 -resultdir        [Optional] Specifies the directory to save the logs.
 Usage examples:
 # Display this help

--- a/collect-logs.sh
+++ b/collect-logs.sh
@@ -17,7 +17,6 @@ Options:
 -namespace        [Optional] Specifies the the namespace of Trend Micro Cloud One container security deployment.
                              The default is the current namespace or default.
 -corefilepattern  [Optional] Specifies the core dump file name prefix pattern. The default value is 'core'.
--resultdir        [Optional] Specifies the directory to save the logs.
 Usage examples:
 # Display this help
 ./collect-logs.sh -h | H


### PR DESCRIPTION
It is required for us to set the context in the logs to select which cluster should be used.
I have removed the need to use Environment variables and instead provide parameters. (Similar to smartcheck implementation)
I have implemented a context switch to switch between prod and staging Kubernetes cluster.

The Readme has been updated to Reflect the changes.
I was able to use this locally to provide logs to your support team.