### PR TITLE
Resolve naming issue in scan-manager-rolebinding ClusterRoleBinding

### DIFF
--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -310,7 +310,7 @@ If release name contains chart name it will be used as a full name.
 {{- else -}}
 {{- $name := default .Chart.Name .Values.scanManagerFullnameOverride -}}
 {{- if contains $name .Release.Name -}}
-{{- printf "%s-%s" "scanManager" .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- printf "%s-%s" "scan-manager" .Release.Name | trunc 63 | trimSuffix "-" -}}
 {{- else if contains .Release.Name $name -}}
 {{- printf "%s-%s" "scan-manager" $name | trunc 63 | trimSuffix "-" -}}
 {{- else -}}


### PR DESCRIPTION
## Trend Micro Case
06489140

## Description
Following PR resolves error with subject name in [scan-manager-role.yaml](https://github.com/trendmicro/cloudone-container-security-helm/blob/master/templates/scan-manager-role.yaml#L49) template file.

## Issue
When installing helm chart following error returned by k8s API:
```
ClusterRoleBinding.rbac.authorization.k8s.io "scan-manager-rolebinding" is invalid: subjects[0].name: Invalid value: "scanManager-trendmicro-container-security": a lowercase RFC 1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')
```

Error caused by use of camelcase in subject resource name in `ClusterRoleBinding` produced by templating `scan-manager-role.yaml`:
![image](https://user-images.githubusercontent.com/65021408/216581958-20251108-0171-4ed8-9e27-cfe1497faf41.png)

## Steps to reproduce

1. Create value-overrides.yaml
```yaml 
cloudOne:
  endpoint: https://container.us-1.cloudone.trendmicro.com/
  runtimeSecurity:
    enabled: false
  vulnerabilityScanning:
    enabled: true
  exclusion:
    namespaces:
      - kube-system
useExistingSecrets: true
```

2. Run `helm template` or `helm install` commands:
```bash
helm template trendmicro-container-security -n trendmicro-system https://github.com/trendmicro/cloudone-container-security-helm/archive/2.3.9.tar.gz -f value-overrides.yaml
```